### PR TITLE
More findEntitiesByPropertyValue fixes

### DIFF
--- a/igc-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/model/common/Identity.java
+++ b/igc-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/model/common/Identity.java
@@ -161,7 +161,7 @@ public class Identity {
         } else if (ctxAssetType.equals("category")) {
             pathSoFar = pathSoFar + "parent_category";
         } else {
-            pathSoFar = pathSoFar + ctxAssetType;
+            pathSoFar = pathSoFar + Reference.getAssetTypeForSearch(ctxAssetType);
         }
         return pathSoFar;
     }


### PR DESCRIPTION
- use search-based property names for IGC query (ie. `host` rather than `host_(engine)`)
- skip (non-)generated entities from results, if searching by `qualifiedName`