### PR TITLE
Rewrites next page URLs to re-use connector configuration

### DIFF
--- a/igc-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/IGCRestClient.java
+++ b/igc-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/IGCRestClient.java
@@ -792,6 +792,10 @@ public class IGCRestClient {
                 if (this.workflowEnabled && !sNextURL.contains("workflowMode=draft")) {
                     sNextURL += "&workflowMode=draft";
                 }
+                if (!sNextURL.startsWith(baseURL)) {
+                    UriComponents components = UriComponentsBuilder.fromHttpUrl(sNextURL).build(true);
+                    log.warn("Configured base URL of environment ({}) does not match IGC's own configuration (https://{}:{}) -- likely to be odd failures ahead.", baseURL, components.getHost(), components.getPort());
+                }
                 String nextPageBody = makeRequest(sNextURL.substring(baseURL.length()), HttpMethod.GET, null, null);
                 // If the page is part of an ASSET retrieval, we need to strip off the attribute
                 // name of the relationship for proper multi-page composition

--- a/igc-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/IGCRestClient.java
+++ b/igc-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/IGCRestClient.java
@@ -792,11 +792,12 @@ public class IGCRestClient {
                 if (this.workflowEnabled && !sNextURL.contains("workflowMode=draft")) {
                     sNextURL += "&workflowMode=draft";
                 }
-                if (!sNextURL.startsWith(baseURL)) {
-                    UriComponents components = UriComponentsBuilder.fromHttpUrl(sNextURL).build(true);
-                    log.warn("Configured base URL of environment ({}) does not match IGC's own configuration (https://{}:{}) -- likely to be odd failures ahead.", baseURL, components.getHost(), components.getPort());
-                }
-                String nextPageBody = makeRequest(sNextURL.substring(baseURL.length()), HttpMethod.GET, null, null);
+                // Strip off the hostname and port number details from the IGC response, to replace with details used
+                // in configuration of the connector (allowing a proxy or other server in front)
+                UriComponents components = UriComponentsBuilder.fromHttpUrl(sNextURL).build(true);
+                String embeddedHost = "https://" + components.getHost() + ":" + components.getPort();
+                String nextUrlNoHost = sNextURL.substring(embeddedHost.length() + 1);
+                String nextPageBody = makeRequest(nextUrlNoHost, HttpMethod.GET, null, null);
                 // If the page is part of an ASSET retrieval, we need to strip off the attribute
                 // name of the relationship for proper multi-page composition
                 if (sNextURL.contains(EP_ASSET)) {


### PR DESCRIPTION
In cases where an environment is configured behind a proxy or independent HTTP server, the URL included in IGC's response that specifies a next page of results could include a different host / port than the connector itself is configured to use.

This update ensures that the connector's configuration is re-used (ie. the URL included in IGC's response is re-written to use the connector's specified host and port).