### PR TITLE
Resolves various Fortify scan-identified issues

### DIFF
--- a/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/DataStageConnector.java
+++ b/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/DataStageConnector.java
@@ -146,7 +146,7 @@ public class DataStageConnector extends DataEngineConnectorBase {
      * {@inheritDoc}
      */
     @Override
-    public Date getChangesLastSynced() {
+    public synchronized Date getChangesLastSynced() {
         InformationGovernanceRule jobSyncRule = getJobSyncRule();
         Date lastSync = null;
         if (jobSyncRule != null) {
@@ -165,7 +165,7 @@ public class DataStageConnector extends DataEngineConnectorBase {
      * {@inheritDoc}
      */
     @Override
-    public void setChangesLastSynced(Date time) {
+    public synchronized void setChangesLastSynced(Date time) {
         final String methodName = "setChangesLastSynced";
         InformationGovernanceRule exists = getJobSyncRule();
         String newDescription = SYNC_RULE_DESC + syncDateFormat.format(time);

--- a/ia-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/ia/clientlibrary/IARestConstants.java
+++ b/ia-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/ia/clientlibrary/IARestConstants.java
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.egeria.connectors.ibm.ia.clientlibrary;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Set of constants for IA REST API usage.
+ */
+public class IARestConstants {
+
+    public static final Pattern COOKIE_WHITELIST = Pattern.compile("^[{}.+/=:; a-zA-Z0-9_%\\-]+$");
+
+    private static final Set<String> VALID_COOKIE_NAMES = createValidCookieNames();
+    private static Set<String> createValidCookieNames() {
+        Set<String> set = new HashSet<>();
+        set.add("LtpaToken2");
+        set.add("JSESSIONID");
+        set.add("X-IBM-IISSessionId");
+        set.add("X-IBM-IISSessionToken");
+        return set;
+    }
+
+    /**
+     * Retrieve the set of valid cookie names for the IGC REST API.
+     *
+     * @return {@code Set<String>}
+     */
+    public static Set<String> getValidCookieNames() { return VALID_COOKIE_NAMES; }
+
+}

--- a/ia-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/ia/clientlibrary/errors/IAConnectivityException.java
+++ b/ia-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/ia/clientlibrary/errors/IAConnectivityException.java
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.egeria.connectors.ibm.ia.clientlibrary.errors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * IGCConnectivityException is used for any unexpected connectivity issues hit by the IGC client library.
+ */
+public class IAConnectivityException extends IAException {
+
+    private static final Logger log = LoggerFactory.getLogger(IAConnectivityException.class);
+
+    /**
+     * Constructor used for creating an IAConnectivityException when an unexpected error has been caught that was
+     * caused by some other error.
+     * @param errorMessage description of error
+     * @param caughtError previous error causing this exception
+     */
+    public IAConnectivityException(String errorMessage, Throwable caughtError) {
+        super(errorMessage, caughtError);
+    }
+
+    /**
+     * Constructor used for creating an IAConnectivityException with some additional details, when not caused by some
+     * other underlying error
+     * @param errorMessage description of error
+     * @param details details about the description of the error
+     */
+    public IAConnectivityException(String errorMessage, String details) {
+        super(errorMessage);
+        log.error("Details for connectivity issue '{}': {}", errorMessage, details);
+    }
+
+}

--- a/ia-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/ia/clientlibrary/errors/IAException.java
+++ b/ia-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/ia/clientlibrary/errors/IAException.java
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.egeria.connectors.ibm.ia.clientlibrary.errors;
+
+public class IAException extends RuntimeException {
+
+    /**
+     * Default constructor used for creating an IAException when an unexpected error has been caught.
+     * @param errorMessage description of the error
+     */
+    public IAException(String errorMessage) { super(errorMessage); }
+
+    /**
+     * Constructor used for creating an IAException when an unexpected error has been caught that was caused by
+     * some other error.
+     * @param errorMessage description of error
+     * @param caughtError previous error causing this exception
+     */
+    public IAException(String errorMessage, Throwable caughtError) {
+        super(errorMessage, caughtError);
+    }
+
+}

--- a/ia-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/ia/clientlibrary/errors/IAParsingException.java
+++ b/ia-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/ia/clientlibrary/errors/IAParsingException.java
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.egeria.connectors.ibm.ia.clientlibrary.errors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * IAParsingException is used for any problems parsing JSON information by the client library.
+ */
+public class IAParsingException extends IAException {
+
+    private static final Logger log = LoggerFactory.getLogger(IAParsingException.class);
+
+    /**
+     * Constructor used for creating an IAParsingException when an unexpected error has been caught based on some
+     * other underlying error and we are simply re-throwing.
+     *
+     * @param errorMessage description of error
+     * @param caughtError previous error causing this exception
+     */
+    public IAParsingException(String errorMessage, Throwable caughtError) {
+        super(errorMessage, caughtError);
+    }
+
+    /**
+     * Constructor used for creating an IAParsingException when an unexpected error has been caught based on some
+     * other underlying error.
+     * @param errorMessage description of error
+     * @param details details of the error, used only for logging purposes
+     * @param caughtError previous error causing this exception
+     */
+    public IAParsingException(String errorMessage, String details, Throwable caughtError) {
+        super(errorMessage, caughtError);
+        log.error("Parsing exception details for '{}': {}", errorMessage, details);
+    }
+
+}

--- a/ia-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/ia/clientlibrary/errors/package-info.java
+++ b/ia-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/ia/clientlibrary/errors/package-info.java
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+
+/**
+ * Describes the error conditions that can occur within the IA client library.
+ */
+package org.odpi.egeria.connectors.ibm.ia.clientlibrary.errors;

--- a/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/attributes/AttributeMapping.java
+++ b/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/attributes/AttributeMapping.java
@@ -304,11 +304,15 @@ public abstract class AttributeMapping {
                 igcValue = ((EnumPropertyValue) value).getSymbolicName();
                 break;
             case ARRAY:
-                igcValue = "[ ";
+                StringBuilder sb = new StringBuilder();
+                sb.append("[ ");
                 Map<String, InstancePropertyValue> arrayValues = ((ArrayPropertyValue) value).getArrayValues().getInstanceProperties();
                 for (Map.Entry<String, InstancePropertyValue> nextEntry : arrayValues.entrySet()) {
-                    igcValue += "\"" + getIgcValueFromPropertyValue(nextEntry.getValue()) + "\",";
+                    sb.append("\"");
+                    sb.append(getIgcValueFromPropertyValue(nextEntry.getValue()));
+                    sb.append("\",");
                 }
+                igcValue = sb.toString();
                 if (igcValue.endsWith(",")) {
                     igcValue = igcValue.substring(0, igcValue.length() - 1);
                 }

--- a/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/classifications/ClassificationMapping.java
+++ b/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/classifications/ClassificationMapping.java
@@ -315,8 +315,9 @@ public abstract class ClassificationMapping extends InstanceMapping {
         Map<String, TypeDefAttribute> omrsAttributeMap = igcomrsMetadataCollection.getTypeDefAttributesForType(omrsClassificationType);
 
         // Then we'll iterate through the provided mappings to set an OMRS instance property for each one
-        for (String igcPropertyName : mappingByIgcProperty.keySet()) {
-            String omrsAttribute = mappingByIgcProperty.get(igcPropertyName).getOmrsPropertyName();
+        for (Map.Entry<String, EntityMapping.PropertyMapping> entry : mappingByIgcProperty.entrySet()) {
+            String igcPropertyName = entry.getKey();
+            String omrsAttribute = entry.getValue().getOmrsPropertyName();
             if (omrsAttributeMap.containsKey(omrsAttribute)) {
                 TypeDefAttribute typeDefAttribute = omrsAttributeMap.get(omrsAttribute);
                 classificationProperties = AttributeMapping.addPrimitivePropertyToInstance(

--- a/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/entities/DataClassMapper.java
+++ b/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/entities/DataClassMapper.java
@@ -398,7 +398,7 @@ public class DataClassMapper extends ReferenceableMapper {
                     break;
                 case "userDefined":
                     if (igcVersion.isEqualTo(IGCVersionEnum.V11702) || igcVersion.isHigherThan(IGCVersionEnum.V11702)) {
-                        boolean isUserDefined = Boolean.getBoolean(omrsValue);
+                        boolean isUserDefined = Boolean.parseBoolean(omrsValue);
                         IGCSearchCondition igcSearchCondition = new IGCSearchCondition(
                                 "provider",
                                 isUserDefined ? "<>" : "=",

--- a/igc-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/IGCRestConstants.java
+++ b/igc-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/IGCRestConstants.java
@@ -20,7 +20,8 @@ public class IGCRestConstants {
     public static final String MOD_MODIFIED_BY = "modified_by";
     public static final String MOD_MODIFIED_ON = "modified_on";
 
-    public static final Pattern INVALID_NAMING_CHARS = Pattern.compile("[.()/&$\\- ]");
+    public static final Pattern NAMING_CHAR_WHITELIST = Pattern.compile("[^a-zA-Z0-9_]");
+    public static final Pattern COOKIE_WHITELIST = Pattern.compile("^[{}.+/=:; a-zA-Z0-9_%\\-]+$");
 
     public static final String IGC_REST_COMMON_MODEL_PKG = "org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.common";
     public static final String IGC_REST_BASE_MODEL_PKG = "org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.base";
@@ -40,6 +41,16 @@ public class IGCRestConstants {
     private static final String REFERENCE = "reference";
     private static final String DATAGROUP = "datagroup";
     public static final String CLASSIFICATIONENABLEDGROUP = "classificationenabledgroup";
+
+    private static final Set<String> VALID_COOKIE_NAMES = createValidCookieNames();
+    private static Set<String> createValidCookieNames() {
+        Set<String> set = new HashSet<>();
+        set.add("LtpaToken2");
+        set.add("JSESSIONID");
+        set.add("X-IBM-IISSessionId");
+        set.add("X-IBM-IISSessionToken");
+        return set;
+    }
 
     private static final List<String> MODIFICATION_DETAILS = createModificationDetails();
     private static List<String> createModificationDetails() {
@@ -255,6 +266,13 @@ public class IGCRestConstants {
     }
 
     /**
+     * Retrieve the set of valid cookie names for the IGC REST API.
+     *
+     * @return {@code Set<String>}
+     */
+    public static Set<String> getValidCookieNames() { return VALID_COOKIE_NAMES; }
+
+    /**
      * Retrieve a list of the modification detail properties used by the IGC REST API.
      *
      * @return {@code List<String>}
@@ -391,7 +409,7 @@ public class IGCRestConstants {
      * @return String
      */
     public static String getCamelCase(String input) {
-        Matcher m = INVALID_NAMING_CHARS.matcher(input);
+        Matcher m = NAMING_CHAR_WHITELIST.matcher(input);
         String invalidsRemoved = m.replaceAll("_");
         StringBuilder sb = new StringBuilder(invalidsRemoved.length());
         for (String token : invalidsRemoved.split("_")) {

--- a/igc-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/update/IGCCreate.java
+++ b/igc-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/update/IGCCreate.java
@@ -50,8 +50,8 @@ public class IGCCreate {
     public JsonNode getCreate() {
         ObjectNode create = nf.objectNode();
         create.put("_type", type);
-        for (String propertyName : properties.keySet()) {
-            create.set(propertyName, nf.textNode(properties.get(propertyName)));
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            create.set(entry.getKey(), nf.textNode(entry.getValue()));
         }
         return create;
     }

--- a/igc-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/update/IGCUpdate.java
+++ b/igc-clientlibrary/src/main/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/update/IGCUpdate.java
@@ -97,13 +97,14 @@ public class IGCUpdate {
     public JsonNode getUpdate() {
         ObjectNode update = nf.objectNode();
         if (!properties.isEmpty()) {
-            for (String propertyName : properties.keySet()) {
-                update.set(propertyName, nf.textNode(properties.get(propertyName)));
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                update.set(entry.getKey(), nf.textNode(entry.getValue()));
             }
         }
         if (!relationships.isEmpty()) {
-            for (String propertyName : relationships.keySet()) {
-                List<String> rids = relationships.get(propertyName);
+            for (Map.Entry<String, List<String>> entry : relationships.entrySet()) {
+                String propertyName = entry.getKey();
+                List<String> rids = entry.getValue();
                 ArrayNode ridArray = nf.arrayNode(rids.size());
                 for (String rid : rids) {
                     ridArray.add(rid);
@@ -123,8 +124,8 @@ public class IGCUpdate {
             }
         }
         if (!exclusiveRelationships.isEmpty()) {
-            for (String propertyName : exclusiveRelationships.keySet()) {
-                update.set(propertyName, nf.textNode(exclusiveRelationships.get(propertyName)));
+            for (Map.Entry<String, String> entry : exclusiveRelationships.entrySet()) {
+                update.set(entry.getKey(), nf.textNode(entry.getValue()));
             }
         }
         return update;

--- a/igc-clientlibrary/src/test/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/NamingTest.java
+++ b/igc-clientlibrary/src/test/java/org/odpi/egeria/connectors/ibm/igc/clientlibrary/NamingTest.java
@@ -8,8 +8,6 @@ import static org.testng.Assert.*;
 
 public class NamingTest {
 
-    private String COMPOUND_TYPE_NAME = "database_column";
-
     public NamingTest() {
         // Do nothing...
     }
@@ -17,10 +15,16 @@ public class NamingTest {
     @Test
     public void testCamelCases() {
 
-        assertEquals(IGCRestConstants.getCamelCase(COMPOUND_TYPE_NAME), "DatabaseColumn");
-        assertEquals(IGCRestConstants.getLowerCamelCase(COMPOUND_TYPE_NAME), "databaseColumn");
-        assertEquals(IGCRestConstants.getGetterNameForProperty(COMPOUND_TYPE_NAME), "getDatabaseColumn");
-        assertEquals(IGCRestConstants.getSetterNameForProperty(COMPOUND_TYPE_NAME), "setDatabaseColumn");
+        String compoundTypeName = "database_column";
+
+        assertEquals(IGCRestConstants.getCamelCase(compoundTypeName), "DatabaseColumn");
+        assertEquals(IGCRestConstants.getLowerCamelCase(compoundTypeName), "databaseColumn");
+        assertEquals(IGCRestConstants.getGetterNameForProperty(compoundTypeName), "getDatabaseColumn");
+        assertEquals(IGCRestConstants.getSetterNameForProperty(compoundTypeName), "setDatabaseColumn");
+
+        String problemCharactersTypeName = "does\nnot actually[exist";
+
+        assertEquals(IGCRestConstants.getCamelCase(problemCharactersTypeName), "DoesNotActuallyExist");
 
     }
 


### PR DESCRIPTION
- Makes date formatting thread-safe
- Adds white lists to validate cookies (HTTP headers)
- Adds white list to validate filenames
- Replaces various IA logging with exception throwing
- Fixes a left-over use of `getBoolean` with `parseBoolean`