### PR TITLE
Ensures any cache misses in DataStage proxy are individually looked up

### DIFF
--- a/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/model/DataStageJob.java
+++ b/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/model/DataStageJob.java
@@ -238,6 +238,8 @@ public class DataStageJob {
     /**
      * Retrieve a listing of all of the data assets (to field-level granularity) this particular DataStage job reads
      * from or writes to.
+     *
+     * @param cache cache and connectivity to IGC environment
      */
     private void classifyFields(DataStageCache cache) {
         if (!getType().equals(JobType.SEQUENCE)) {

--- a/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/model/DataStageJob.java
+++ b/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/model/DataStageJob.java
@@ -140,7 +140,13 @@ public class DataStageJob {
      */
     public Link getLinkByRid(String rid) {
         log.debug("Looking up cached link: {}", rid);
-        return linkMap.getOrDefault(rid, null);
+        Link link = linkMap.getOrDefault(rid, null);
+        if (link == null) {
+            log.debug("(cache miss) -- retrieving and caching link: {}", rid);
+            link = (Link) igcRestClient.getAssetById(rid);
+            linkMap.put(rid, link);
+        }
+        return link;
     }
 
     /**
@@ -151,7 +157,13 @@ public class DataStageJob {
      */
     public StageColumn getStageColumnByRid(String rid) {
         log.debug("Looking up cached stage column: {}", rid);
-        return columnMap.getOrDefault(rid, null);
+        StageColumn stageColumn = columnMap.getOrDefault(rid, null);
+        if (stageColumn == null) {
+            log.debug("(cache miss) -- retrieving and caching stage column: {}", rid);
+            stageColumn = (StageColumn) igcRestClient.getAssetById(rid);
+            columnMap.put(rid, stageColumn);
+        }
+        return stageColumn;
     }
 
     /**
@@ -226,8 +238,6 @@ public class DataStageJob {
     /**
      * Retrieve a listing of all of the data assets (to field-level granularity) this particular DataStage job reads
      * from or writes to.
-     *
-     * @param cache cache and connectivity to IGC environment
      */
     private void classifyFields(DataStageCache cache) {
         if (!getType().equals(JobType.SEQUENCE)) {


### PR DESCRIPTION
In particular for both stage columns and links (data stores and their fields should already be handled).