### PR TITLE
Ensures relationship with a missing endpoint returns null GUID

### DIFF
--- a/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/relationships/RelationshipMapping.java
+++ b/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/relationships/RelationshipMapping.java
@@ -1044,7 +1044,7 @@ public abstract class RelationshipMapping extends InstanceMapping {
                         relationshipLevelRid,
                         omrsRelationshipName
                 );
-            } else {
+            } else if (proxyOneRid != null && proxyTwoRid != null) {
                 igcRelationshipGuid = igcRepositoryHelper.getRelationshipGuid(
                         endOneType,
                         endTwoType,
@@ -1054,6 +1054,8 @@ public abstract class RelationshipMapping extends InstanceMapping {
                         proxyTwoRid,
                         omrsRelationshipName
                 );
+            } else {
+                log.error("One or both ends of the relationship {} between {} and {} cannot be resolved -- skipping the relationship.", omrsRelationshipName, endOneType, endTwoType);
             }
         }
 


### PR DESCRIPTION
So that any relationship with one end that is not mapped means that the relationship itself will be skipped.