### PR TITLE
Add primary category mapper

### DIFF
--- a/datastage-adapter/src/test/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/ConnectorTest.java
+++ b/datastage-adapter/src/test/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/ConnectorTest.java
@@ -146,18 +146,6 @@ public class ConnectorTest {
     }
 
     @Test
-    public void testPortImplementations() {
-        List<PortImplementation> portImplementations = dataStageConnector.getChangedPortImplementations(null, now);
-        assertTrue(portImplementations.isEmpty());
-    }
-
-    @Test
-    public void testPortAliases() {
-        List<PortAlias> portAliases = dataStageConnector.getChangedPortAliases(null, now);
-        assertTrue(portAliases.isEmpty());
-    }
-
-    @Test
     public void testProcesses() {
         List<Process> processes = dataStageConnector.getChangedProcesses(null, now);
         assertFalse(processes.isEmpty());

--- a/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/classifications/PrimaryCategoryMapper.java
+++ b/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/classifications/PrimaryCategoryMapper.java
@@ -50,10 +50,9 @@ public class PrimaryCategoryMapper extends ClassificationMapping {
 
     /**
      * Implements the "PrimaryCategory" classification for IGC objects (by default we only apply to terms).
-     * We use the 'assigned_to_term' relationship from one term to any term
-     * within a parent category to represent the "PrimaryCategory" classification in OMRS.
-     * Therefore, any 'assigned_to_term' relationship on a term, where the assigned term is within a
-     * parent category in IGC, will be mapped to a "PrimaryCategory" classification in OMRS.
+     * We use the parent identify to represent categoryQualifiedName field which is the only property of the
+     * "PrimaryCategory" classification in OMRS.
+     * Therefore, all terms parents identities will be mapped to a "PrimaryCategory" classification in OMRS.
      *
      * @param igcomrsRepositoryConnector connectivity to the IGC environment
      * @param classifications the list of classifications to which to add

--- a/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/classifications/PrimaryCategoryMapper.java
+++ b/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/classifications/PrimaryCategoryMapper.java
@@ -1,0 +1,154 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.egeria.connectors.ibm.igc.repositoryconnector.mapping.classifications;
+
+import org.odpi.egeria.connectors.ibm.igc.auditlog.IGCOMRSErrorCode;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.IGCRestClient;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.IGCVersionEnum;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.cache.ObjectCache;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.errors.IGCException;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.base.Term;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.common.Identity;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.common.Reference;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.search.IGCSearchCondition;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.search.IGCSearchConditionSet;
+import org.odpi.egeria.connectors.ibm.igc.repositoryconnector.IGCOMRSRepositoryConnector;
+import org.odpi.egeria.connectors.ibm.igc.repositoryconnector.IGCRepositoryHelper;
+import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.properties.instances.Classification;
+import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.properties.instances.InstanceProperties;
+import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.properties.search.PropertyCondition;
+import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.properties.search.SearchProperties;
+import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.repositoryconnector.OMRSRepositoryHelper;
+import org.odpi.openmetadata.repositoryservices.ffdc.exception.FunctionNotSupportedException;
+import org.odpi.openmetadata.repositoryservices.ffdc.exception.RepositoryErrorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * The type Primary category mapper.
+ */
+public class PrimaryCategoryMapper extends ClassificationMapping {
+
+    private static final Logger log = LoggerFactory.getLogger(PrimaryCategoryMapper.class);
+
+    private static PrimaryCategoryMapper primaryCategoryMapper;
+
+    private PrimaryCategoryMapper() {
+        super(IGCRepositoryHelper.DEFAULT_IGC_TYPE, "assigned_to_terms", "GlossaryTerm",
+                "PrimaryCategory");
+        addMappedOmrsProperty("categoryQualifiedName");
+    }
+
+    public static ClassificationMapping getInstance(IGCVersionEnum version) {
+        if(primaryCategoryMapper == null) {
+            primaryCategoryMapper = new PrimaryCategoryMapper();
+        }
+        return primaryCategoryMapper;
+    }
+
+    /**
+     * Implements the "PrimaryCategory" classification for IGC objects (by default we only apply to terms).
+     * We use the 'assigned_to_term' relationship from one term to any term
+     * within a parent category to represent the "PrimaryCategory" classification in OMRS.
+     * Therefore, any 'assigned_to_term' relationship on a term, where the assigned term is within a
+     * parent category in IGC, will be mapped to a "PrimaryCategory" classification in OMRS.
+     *
+     * @param igcomrsRepositoryConnector connectivity to the IGC environment
+     * @param classifications the list of classifications to which to add
+     * @param cache a cache of information that may already have been retrieved about the provided object
+     * @param fromIgcObject the IGC object for which the classification should exist
+     * @param userId the user requesting the mapped classifications
+     * @throws RepositoryErrorException if any issue interacting with IGC
+     */
+    @Override
+    public void addMappedOMRSClassifications(IGCOMRSRepositoryConnector igcomrsRepositoryConnector,
+                                             List<Classification> classifications,
+                                             ObjectCache cache,
+                                             Reference fromIgcObject,
+                                             String userId) throws RepositoryErrorException {
+
+        final String methodName = "addMappedOMRSClassification";
+
+        if (fromIgcObject instanceof Term) {
+           try {
+                IGCRestClient igcRestClient = igcomrsRepositoryConnector.getIGCRestClient();
+                Identity termIdentity = fromIgcObject.getIdentity(igcRestClient, cache);
+                Identity catIdentity = termIdentity.getParentIdentity();
+
+                InstanceProperties classificationProperties = new InstanceProperties();
+
+                classificationProperties = igcomrsRepositoryConnector.getRepositoryHelper().addStringPropertyToInstance(
+                        igcomrsRepositoryConnector.getRepositoryName(),
+                        classificationProperties,
+                        "categoryQualifiedName",
+                        catIdentity.getName(),
+                        methodName
+                );
+                Classification classification = getMappedClassification(
+                        igcomrsRepositoryConnector,
+                        classificationProperties,
+                        fromIgcObject,
+                        userId
+                );
+                classifications.add(classification);
+                log.debug("Add categoryQualifiedName property with value '{}' to classification {} of term {}", catIdentity.getName(),
+                        classification.getName(), termIdentity.getName());
+            } catch (NumberFormatException | IGCException e) {
+                raiseRepositoryErrorException(IGCOMRSErrorCode.UNKNOWN_RUNTIME_ERROR, methodName, e);
+            }
+        }
+    }
+
+    /**
+     * Search for PrimaryCategory by looking for a term assignment where the assigned term sits under a
+     * PrimaryCategory parent category.
+     *
+     * @param repositoryHelper the repository helper
+     * @param repositoryName name of the repository
+     * @param matchProperties the criteria to use when searching for the classification
+     * @return IGCSearchConditionSet - the IGC search criteria to find entities based on this classification
+     * @throws FunctionNotSupportedException when an invalid enumeration is requested
+     */
+    @Override
+    public IGCSearchConditionSet getIGCSearchCriteria(OMRSRepositoryHelper repositoryHelper,
+                                                      String repositoryName,
+                                                      SearchProperties matchProperties) throws FunctionNotSupportedException {
+
+        IGCSearchCondition igcSearchCondition = new IGCSearchCondition(
+                "assigned_to_terms.parent_category",
+                "isNull",
+                false
+        );
+        IGCSearchConditionSet igcSearchConditionSet = new IGCSearchConditionSet(igcSearchCondition);
+
+        if (matchProperties != null) {
+            IGCSearchConditionSet byProperties = getConditionsForProperties(matchProperties);
+            if (byProperties.size() > 0) {
+                igcSearchConditionSet.addNestedConditionSet(byProperties);
+                igcSearchConditionSet.setMatchAnyCondition(false);
+            }
+        }
+        return igcSearchConditionSet;
+    }
+
+    private IGCSearchConditionSet getConditionsForProperties(SearchProperties matchProperties) {
+
+        IGCSearchConditionSet set = new IGCSearchConditionSet();
+
+        List<PropertyCondition> propertyConditions = matchProperties.getConditions();
+        for (PropertyCondition condition : propertyConditions) {
+            SearchProperties nestedProperties = condition.getNestedConditions();
+            if (nestedProperties != null) {
+                IGCSearchConditionSet nestedSet = getConditionsForProperties(nestedProperties);
+                IGCRepositoryHelper.setConditionsFromMatchCriteria(nestedSet, nestedProperties.getMatchCriteria());
+                set.addNestedConditionSet(nestedSet);
+            }
+        }
+        IGCRepositoryHelper.setConditionsFromMatchCriteria(set, matchProperties.getMatchCriteria());
+
+        return set;
+    }
+
+}

--- a/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/classifications/PrimaryCategoryMapper.java
+++ b/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/classifications/PrimaryCategoryMapper.java
@@ -74,7 +74,7 @@ public class PrimaryCategoryMapper extends ClassificationMapping {
            try {
                 IGCRestClient igcRestClient = igcomrsRepositoryConnector.getIGCRestClient();
                 Identity termIdentity = fromIgcObject.getIdentity(igcRestClient, cache);
-                Identity catIdentity = termIdentity.getParentIdentity();
+                Identity categoryIdentity = termIdentity.getParentIdentity();
 
                 InstanceProperties classificationProperties = new InstanceProperties();
 
@@ -82,7 +82,7 @@ public class PrimaryCategoryMapper extends ClassificationMapping {
                         igcomrsRepositoryConnector.getRepositoryName(),
                         classificationProperties,
                         CATEGORY_QUALIFIED_NAME,
-                        catIdentity.toString(),
+                        categoryIdentity.toString(),
                         methodName
                 );
                 Classification classification = getMappedClassification(
@@ -95,7 +95,7 @@ public class PrimaryCategoryMapper extends ClassificationMapping {
                 classifications.add(classification);
 
                 log.debug(ADD_CATEGORY_QUALIFIED_NAME_PROPERTY_WITH_VALUE_TO_CLASSIFICATION_OF_TERM,
-                        catIdentity.toString(), classification.getName(), termIdentity.getName());
+                        categoryIdentity.toString(), classification.getName(), termIdentity.getName());
 
             } catch (NumberFormatException | IGCException e) {
                 raiseRepositoryErrorException(IGCOMRSErrorCode.UNKNOWN_RUNTIME_ERROR, methodName, e);

--- a/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/entities/GlossaryTermMapper.java
+++ b/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/entities/GlossaryTermMapper.java
@@ -12,6 +12,7 @@ import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.common.Identity;
 import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.common.Reference;
 import org.odpi.egeria.connectors.ibm.igc.clientlibrary.search.IGCSearchCondition;
 import org.odpi.egeria.connectors.ibm.igc.clientlibrary.search.IGCSearchConditionSet;
+import org.odpi.egeria.connectors.ibm.igc.repositoryconnector.mapping.classifications.PrimaryCategoryMapper;
 import org.odpi.egeria.connectors.ibm.igc.repositoryconnector.mapping.classifications.SpineAttributeMapper;
 import org.odpi.egeria.connectors.ibm.igc.repositoryconnector.mapping.relationships.*;
 import org.odpi.egeria.connectors.ibm.igc.repositoryconnector.mapping.classifications.ConfidentialityMapper;
@@ -62,7 +63,7 @@ public class GlossaryTermMapper extends ReferenceableMapper {
         addClassificationMapper(ConfidentialityMapper.getInstance(null));
         addClassificationMapper(SpineObjectMapper.getInstance(null));
         addClassificationMapper(SpineAttributeMapper.getInstance(null));
-
+        addClassificationMapper(PrimaryCategoryMapper.getInstance(null));
     }
 
     /**

--- a/igc-adapter/src/test/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/ConnectorTest.java
+++ b/igc-adapter/src/test/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/ConnectorTest.java
@@ -2432,7 +2432,7 @@ public class ConnectorTest {
         List<Classification> classifications = detail.getClassifications();
         assertNotNull(classifications);
         assertFalse(classifications.isEmpty());
-        assertEquals(classifications.size(), 1);
+        assertEquals(classifications.size(), 2);
         Classification first = classifications.get(0);
         assertEquals(first.getType().getTypeDefName(), "SpineObject");
         assertTrue(first.getVersion() > 1);

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     </modules>
 
     <properties>
-        <open-metadata.version>2.9-SNAPSHOT</open-metadata.version>
+        <open-metadata.version>2.10-SNAPSHOT</open-metadata.version>
         <connector.version>2.9-SNAPSHOT</connector.version>
         <!-- Level of Java  -->
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
The glossary terms get their Primary Category classification value from the parent category qualified name from IGC. The name is stored in the categoryQualifiedName property.

For the moment Egeria won't be able to search by name this kind of classification. A new implementation is needed for that.