### PR TITLE
Data Stage connector  - add capability to process virtual assets

### DIFF
--- a/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/DataStageConnector.java
+++ b/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/DataStageConnector.java
@@ -467,7 +467,6 @@ public class DataStageConnector extends DataEngineConnectorBase {
      * Translate a single Process to represent the DataStage job itself.
      *
      * @param job the job object for which to load a process
-     *
      * @return Process
      */
     private Process getProcessForJob(DataStageJob job) {
@@ -614,7 +613,7 @@ public class DataStageConnector extends DataEngineConnectorBase {
      * @param params any parameters for formatting the error message
      * @throws ConnectorCheckedException always
      */
-    private void raiseConnectorCheckedException(DataStageErrorCode errorCode, String methodName, String... params) throws ConnectorCheckedException {
+    private void raiseConnectorCheckedException(DataStageErrorCode errorCode, String methodName, String ...params) throws ConnectorCheckedException {
         throw new ConnectorCheckedException(errorCode.getMessageDefinition(params),
                 this.getClass().getName(),
                 methodName);
@@ -626,16 +625,13 @@ public class DataStageConnector extends DataEngineConnectorBase {
 
     /**
      * Throws an OCFRuntimeException using the provided parameters.
-     *
-     * @param errorCode  the error
-     * @param className  of the caller
+     * @param errorCode the error
+     * @param className of the caller
      * @param methodName of the caller
-     * @param cause      of the underlying error, if any
-     *
+     * @param cause of the underlying error, if any
      * @throws OCFRuntimeException always
      */
-    public static void raiseRuntimeError(DataStageErrorCode errorCode, String className, String methodName, Exception cause) throws
-                                                                                                                             OCFRuntimeException {
+    public static void raiseRuntimeError(DataStageErrorCode errorCode, String className, String methodName, Exception cause) throws OCFRuntimeException {
         if (cause == null) {
             throw new OCFRuntimeException(errorCode.getMessageDefinition(),
                     className,

--- a/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/mapping/DataFileMapping.java
+++ b/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/mapping/DataFileMapping.java
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.egeria.connectors.ibm.datastage.dataengineconnector.mapping;
+
+import org.odpi.egeria.connectors.ibm.datastage.dataengineconnector.model.DataStageCache;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.common.Identity;
+import org.odpi.openmetadata.accessservices.dataengine.model.DataFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Mappings for creating a DataFile.
+ */
+public class DataFileMapping extends BaseMapping{
+    private static final Logger log = LoggerFactory.getLogger(DataFileMapping.class);
+
+    public DataFileMapping(DataStageCache cache) {
+        super(cache);
+    }
+
+    /**
+     * Creates a DataFile for the provided data store and field information.
+     *
+     * @param storeIdentity the store identity for which to create the data file
+     * @return DataFile
+     */
+    public DataFile getForDataStore(Identity storeIdentity) {
+        DataFile dataFile = null;
+        if (storeIdentity != null) {
+            dataFile= new DataFile();
+            String dataFileQN = getFullyQualifiedName(storeIdentity, null);
+            if (dataFileQN != null) {
+                log.debug("Constructing DataFile for data store: {}", dataFileQN);
+                dataFile.setQualifiedName(dataFileQN);
+                dataFile.setDisplayName(storeIdentity.getName());
+            } else {
+                log.error("Unable to determine identity of store: {}", storeIdentity);
+            }
+        }
+        return dataFile;
+    }
+}

--- a/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/mapping/DatabaseSchemaMapping.java
+++ b/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/mapping/DatabaseSchemaMapping.java
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.egeria.connectors.ibm.datastage.dataengineconnector.mapping;
+
+import org.odpi.egeria.connectors.ibm.datastage.dataengineconnector.model.DataStageCache;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.common.Identity;
+import org.odpi.openmetadata.accessservices.dataengine.model.DatabaseSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Mappings for creating a DatabaseSchema.
+ */
+public class DatabaseSchemaMapping extends BaseMapping{
+    private static final Logger log = LoggerFactory.getLogger(DatabaseSchemaMapping.class);
+
+    public DatabaseSchemaMapping(DataStageCache cache) {
+        super(cache);
+    }
+
+    /**
+     * Creates a DatabaseSchema for the provided data store and field information.
+     *
+     * @param storeIdentity the store identity for which to create the database schema
+     * @return DatabaseSchema
+     */
+    public DatabaseSchema getForDataStore(Identity storeIdentity) {
+        DatabaseSchema databaseSchema = null;
+        if (storeIdentity != null) {
+            databaseSchema= new DatabaseSchema();
+
+            String schemaTypeQN = getFullyQualifiedName(storeIdentity, null);
+            if (schemaTypeQN != null) {
+                log.debug("Constructing DatabaseSchema for data store: {}", schemaTypeQN);
+                databaseSchema.setQualifiedName(schemaTypeQN);
+                databaseSchema.setDisplayName(storeIdentity.getName());
+            } else {
+                log.error("Unable to determine identity of store: {}", storeIdentity);
+            }
+        }
+        return databaseSchema;
+    }
+}

--- a/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/mapping/LineageMappingMapping.java
+++ b/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/mapping/LineageMappingMapping.java
@@ -7,7 +7,12 @@ import org.odpi.egeria.connectors.ibm.datastage.dataengineconnector.auditlog.Dat
 import org.odpi.egeria.connectors.ibm.datastage.dataengineconnector.model.DataStageCache;
 import org.odpi.egeria.connectors.ibm.datastage.dataengineconnector.model.DataStageJob;
 import org.odpi.egeria.connectors.ibm.igc.clientlibrary.errors.IGCException;
-import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.base.*;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.base.Classificationenabledgroup;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.base.DataItem;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.base.InformationAsset;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.base.Link;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.base.Stage;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.base.StageVariable;
 import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.common.Identity;
 import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.common.ItemList;
 import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.common.Reference;
@@ -196,12 +201,14 @@ class LineageMappingMapping extends BaseMapping {
             String jobQN = getFullyQualifiedName(job.getJobObject());
             for (String rid : inputs) {
                 Identity input = cache.getStoreIdentityFromRid(rid);
-                LineageMapping lineageMapping = getLineageMapping(input.toString(), jobQN);
+                String inputQualifiedName = this.getFullyQualifiedName(input, null);
+                LineageMapping lineageMapping = getLineageMapping(inputQualifiedName, jobQN);
                 lineageMappings.add(lineageMapping);
             }
             for (String rid : outputs) {
                 Identity output = cache.getStoreIdentityFromRid(rid);
-                LineageMapping lineageMapping = getLineageMapping(jobQN, output.toString());
+                String outputQualifiedName = this.getFullyQualifiedName(output, null);
+                LineageMapping lineageMapping = getLineageMapping(jobQN, outputQualifiedName);
                 lineageMappings.add(lineageMapping);
             }
         } catch (IGCException e) {

--- a/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/mapping/RelationalTableMapping.java
+++ b/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/mapping/RelationalTableMapping.java
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.egeria.connectors.ibm.datastage.dataengineconnector.mapping;
+
+import org.odpi.egeria.connectors.ibm.datastage.dataengineconnector.model.DataStageCache;
+import org.odpi.egeria.connectors.ibm.igc.clientlibrary.model.common.Identity;
+import org.odpi.openmetadata.accessservices.dataengine.model.VirtualTable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Mappings for creating a RelationalTable.
+ */
+public class RelationalTableMapping  extends BaseMapping{
+    private static final Logger log = LoggerFactory.getLogger(RelationalTableMapping.class);
+
+    public RelationalTableMapping(DataStageCache cache) {
+        super(cache);
+    }
+
+    /**
+     * Creates a VirtualTable for the provided data store and field information.
+     *
+     * @param storeIdentity the store identity for which to create the virtual table
+     * @return VirtualTable
+     */
+    public VirtualTable getForDataStore(Identity storeIdentity) {
+        VirtualTable relationalTable = null;
+        if (storeIdentity != null) {
+            relationalTable = new VirtualTable();
+            String relationalTableQN = getFullyQualifiedName(storeIdentity, null);
+            if (relationalTableQN != null) {
+                log.debug("Constructing RelationalTable for data store: {}", relationalTableQN);
+                relationalTable.setQualifiedName(relationalTableQN);
+                relationalTable.setDisplayName(storeIdentity.getName());
+            } else {
+                log.error("Unable to determine identity of store: {}", storeIdentity);
+            }
+        }
+        return relationalTable;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     </modules>
 
     <properties>
-        <open-metadata.version>3.0-SNAPSHOT</open-metadata.version>
+        <open-metadata.version>3.3-SNAPSHOT</open-metadata.version>
         <connector.version>3.0-SNAPSHOT</connector.version>
         <!-- Level of Java  -->
         <maven.compiler.source>11</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     </modules>
 
     <properties>
-        <open-metadata.version>3.3-SNAPSHOT</open-metadata.version>
+        <open-metadata.version>3.4-SNAPSHOT</open-metadata.version>
         <connector.version>3.3-SNAPSHOT</connector.version>
         <!-- Level of Java  -->
         <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
Implements #599 
If the mode is JOB_LEVEL and the "includeVirtualAssets" flag is set on true, then the connector will send the information for creating virtual assets(database schemas, relational tables and data files) to DE OMAS. The virtual assets will not have the columns represented.
If the mode is GRANULAR_LEVEL  and the "includeVirtualAssets" flag is set on true, then the old behaviour for virtual assets will apply(creating schemas and columns for them).

