### PR TITLE
Update maven-java16-verify.yml

### DIFF
--- a/.github/workflows/maven-java16-verify.yml
+++ b/.github/workflows/maven-java16-verify.yml
@@ -25,7 +25,7 @@ jobs:
           key: ${{ runner.os }}-maven-java16-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-java16
       - name: Build with Maven
-        run: mvn -DargLine="-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:GCTimeRatio=99" -B clean verify --file pom.xml
+        run: mvn -DargLine="-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:GCTimeRatio=99 --add-opens=java.base/sun.security.x509=ALL-UNNAMED" -B clean verify --file pom.xml
       - name: Upload assemblies
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/maven-java16-verify.yml
+++ b/.github/workflows/maven-java16-verify.yml
@@ -24,8 +24,11 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-maven-java16-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-java16
+      - name: Set Maven Options 
+        env:
+          MAVEN_OPTS: --add-opens=java.base/sun.security.x509=ALL-UNNAMED
       - name: Build with Maven
-        run: mvn -DargLine="-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:GCTimeRatio=99 --add-opens=java.base/sun.security.x509=ALL-UNNAMED" -B clean verify --file pom.xml
+        run: mvn -DargLine="-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:GCTimeRatio=99" -B clean verify --file pom.xml
       - name: Upload assemblies
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/maven-java16-verify.yml
+++ b/.github/workflows/maven-java16-verify.yml
@@ -24,11 +24,10 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-maven-java16-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-java16
-      - name: Set Maven Options 
-        env:
-          MAVEN_OPTS: --add-opens=java.base/sun.security.x509=ALL-UNNAMED
       - name: Build with Maven
         run: mvn -DargLine="-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:GCTimeRatio=99" -B clean verify --file pom.xml
+        env:
+          MAVEN_OPTS: --add-opens=java.base/sun.security.x509=ALL-UNNAMED
       - name: Upload assemblies
         uses: actions/upload-artifact@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     </modules>
 
     <properties>
-        <open-metadata.version>3.3-SNAPSHOT</open-metadata.version>
+        <open-metadata.version>3.4-SNAPSHOT</open-metadata.version>
         <connector.version>3.3-SNAPSHOT</connector.version>
         <!-- Level of Java  -->
         <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
Add extra vm option to fix java16 build with maven.

Should fix Java 16 build failure:

```
Warning:  Failed to initialize a channel. Closing: [id: 0x7cdeea69]
java.lang.RuntimeException: Exception creating SSL context for client
    at org.mockserver.socket.tls.NettySslContextFactory.createClientSslContext (NettySslContextFactory.java:78)
    at org.mockserver.client.HttpClientInitializer.initChannel (HttpClientInitializer.java:70)
    at org.mockserver.client.HttpClientInitializer.initChannel (HttpClientInitializer.java:25)
    at io.netty.channel.ChannelInitializer.initChannel (ChannelInitializer.java:129)
    at io.netty.channel.ChannelInitializer.handlerAdded (ChannelInitializer.java:112)
    at io.netty.channel.AbstractChannelHandlerContext.callHandlerAdded (AbstractChannelHandlerContext.java:938)
    at io.netty.channel.DefaultChannelPipeline.callHandlerAdded0 (DefaultChannelPipeline.java:609)
    at io.netty.channel.DefaultChannelPipeline.access$100 (DefaultChannelPipeline.java:46)
    at io.netty.channel.DefaultChannelPipeline$PendingHandlerAddedTask.execute (DefaultChannelPipeline.java:1463)
    at io.netty.channel.DefaultChannelPipeline.callHandlerAddedForAllHandlers (DefaultChannelPipeline.java:1115)
    at io.netty.channel.DefaultChannelPipeline.invokeHandlerAddedIfNeeded (DefaultChannelPipeline.java:650)
    at io.netty.channel.AbstractChannel$AbstractUnsafe.register0 (AbstractChannel.java:502)
    at io.netty.channel.AbstractChannel$AbstractUnsafe.access$200 (AbstractChannel.java:417)
    at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run (AbstractChannel.java:474)
    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute (AbstractEventExecutor.java:164)
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks (SingleThreadEventExecutor.java:472)
    at io.netty.channel.nio.NioEventLoop.run (NioEventLoop.java:500)
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run (SingleThreadEventExecutor.java:989)
    at io.netty.util.internal.ThreadExecutorMap$2.run (ThreadExecutorMap.java:74)
    at java.lang.Thread.run (Thread.java:831)
Caused by: java.lang.IllegalAccessError: class org.mockserver.socket.tls.jdk.X509Generator (in unnamed module @0x4eef8498) cannot access class sun.security.x509.X500Name (in module java.base) because module java.base does not export sun.security.x509 to unnamed module @0x4eef8498
    at org.mockserver.socket.tls.jdk.X509Generator.generateLeafX509AndPrivateKey (X509Generator.java:52)
    at org.mockserver.socket.tls.jdk.JDKKeyAndCertificateFactory.buildAndSavePrivateKeyAndX509Certificate (JDKKeyAndCertificateFactory.java:195)
    at org.mockserver.socket.tls.NettySslContextFactory.createClientSslContext (NettySslContextFactory.java:51)
    at org.mockserver.client.HttpClientInitializer.initChannel (HttpClientInitializer.java:70)
    at org.mockserver.client.HttpClientInitializer.initChannel (HttpClientInitializer.java:25)
    at io.netty.channel.ChannelInitializer.initChannel (ChannelInitializer.java:129)
    at io.netty.channel.ChannelInitializer.handlerAdded (ChannelInitializer.java:112)
    at io.netty.channel.AbstractChannelHandlerContext.callHandlerAdded (AbstractChannelHandlerContext.java:938)
    at io.netty.channel.DefaultChannelPipeline.callHandlerAdded0 (DefaultChannelPipeline.java:609)
    at io.netty.channel.DefaultChannelPipeline.access$100 (DefaultChannelPipeline.java:46)
    at io.netty.channel.DefaultChannelPipeline$PendingHandlerAddedTask.execute (DefaultChannelPipeline.java:1463)
    at io.netty.channel.DefaultChannelPipeline.callHandlerAddedForAllHandlers (DefaultChannelPipeline.java:1115)
    at io.netty.channel.DefaultChannelPipeline.invokeHandlerAddedIfNeeded (DefaultChannelPipeline.java:650)
    at io.netty.channel.AbstractChannel$AbstractUnsafe.register0 (AbstractChannel.java:502)
    at io.netty.channel.AbstractChannel$AbstractUnsafe.access$200 (AbstractChannel.java:417)
    at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run (AbstractChannel.java:474)
    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute (AbstractEventExecutor.java:164)
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks (SingleThreadEventExecutor.java:472)
    at io.netty.channel.nio.NioEventLoop.run (NioEventLoop.java:500)
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run (SingleThreadEventExecutor.java:989)
    at io.netty.util.internal.ThreadExecutorMap$2.run (ThreadExecutorMap.java:74)
    at java.lang.Thread.run (Thread.java:831)
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Egeria Connectors for IBM Information Server 3.3-SNAPSHOT:
[INFO] 
[INFO] Egeria Connectors for IBM Information Server ....... SUCCESS [ 16.432 s]
[INFO] IBM Information Server Connectors - tests .......... SUCCESS [ 11.534 s]
[INFO] IBM Information Governance Catalog REST API Client Library FAILURE [  8.682 s]
[INFO] IBM Information Governance Catalog Repository Connector SKIPPED
[INFO] IBM DataStage Connector ............................ SKIPPED
[INFO] IBM Information Analyzer REST API Client Library ... SKIPPED
[INFO] Egeria Connector for IBM Information Server - packaging SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  36.870 s
[INFO] Finished at: 2021-11-11T18:09:48Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.mock-server:mockserver-maven-plugin:5.11.2:start (process-test-classes) on project ibm-igc-rest-client-library: Execution process-test-classes of goal org.mock-server:mockserver-maven-plugin:5.11.2:start failed: Channel handler removed before valid response has been received -> [Help 1]```