### PR TITLE
Mapping recently added properties for DataSet and DataContentForDataSet

### DIFF
--- a/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/entities/DataSetMapper.java
+++ b/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/entities/DataSetMapper.java
@@ -29,6 +29,9 @@ public class DataSetMapper extends AssetMapper {
                 omrsEntityTypeName
         );
 
+        // Mapping to default
+        addLiteralPropertyMapping("formula", null);
+
     }
 
 }

--- a/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/relationships/DataContentForDataSetMapper.java
+++ b/igc-adapter/src/main/java/org/odpi/egeria/connectors/ibm/igc/repositoryconnector/mapping/relationships/DataContentForDataSetMapper.java
@@ -27,6 +27,10 @@ public class DataContentForDataSetMapper extends RelationshipMapping {
                 "supportedDataSets"
         );
         setContainedType(ContainedType.TWO);
+
+        // Mapping to default
+        addLiteralPropertyMapping("queryId", null);
+        addLiteralPropertyMapping("query", null);
     }
 
 }


### PR DESCRIPTION
Following recent Area0 types improvement introduced with https://github.com/odpi/egeria/pull/6726/commits/f4320db41e1651f336866a01581c5ba3dcdb025a we need to map the new properties so the verifyTypeDefs phase of the unit tests passes.
Mapping the properties to default (null) value until specific property mapping in the corresponding IGC type is identified.


Signed-off-by: Ljupcho Palashevski <ljupcho.palashevski@ing.com>