### PR TITLE
Performance improvements for lineage  processing

### DIFF
--- a/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/DataStageConnector.java
+++ b/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/DataStageConnector.java
@@ -343,7 +343,8 @@ public class DataStageConnector extends DataEngineConnectorBase {
      * @param to the date and time up to which to cache changes (inclusive)
      */
     private void initializeCache(Date from, Date to) throws IGCException {
-        DataStageCache forComparison = new DataStageCache(from, to, mode, limitToProjects, limitToLabels, limitToLineageEnabledJobs);
+        DataStageCache forComparison = new DataStageCache(from, to, mode, limitToProjects, limitToLabels, limitToLineageEnabledJobs,
+                includeVirtualAssets);
         if (dataStageCache == null || !dataStageCache.equals(forComparison)) {
             // Initialize the cache, if it is empty, or reset it if it differs from the dates and times we've been given
             dataStageCache = forComparison;

--- a/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/DataStageReportsConnector.java
+++ b/datastage-adapter/src/main/java/org/odpi/egeria/connectors/ibm/datastage/dataengineconnector/DataStageReportsConnector.java
@@ -201,6 +201,7 @@ public class DataStageReportsConnector extends DataEngineConnectorBase {
     public List<Process> getChangedProcesses(Date from, Date to) throws ConnectorCheckedException, PropertyServerException {
 
         final String methodName = "getChangedProcesses";
+        log.debug("Looking for changed Processes...");
         List<Process> processes = new ArrayList<>();
 
         try {
@@ -240,9 +241,10 @@ public class DataStageReportsConnector extends DataEngineConnectorBase {
      * @param to the date and time up to which to cache changes (inclusive)
      */
     private void initializeCache(Date from, Date to) throws IGCException {
-        this.dataStageCache = new DataStageCache(from, to, mode, new ArrayList<>(), new ArrayList<>(), false);
-        dataStageCache.initializeWithReportJobs(igcRestClient, startAssetRIDs, detectLineage);
-        processHierarchies = new ArrayList<>();
+        if (dataStageCache == null) {
+            dataStageCache = new DataStageCache(from, to, mode, new ArrayList<>(), new ArrayList<>(), false, includeVirtualAssets);
+            dataStageCache.initializeWithReportJobs(igcRestClient, startAssetRIDs, detectLineage);
+            processHierarchies = new ArrayList<>();
+        }
     }
-
 }


### PR DESCRIPTION
This PR includes the following changes:
* initialise the cache only if it's null - previously the cache was initialised three times, whenever a getChangedXXX method was called
* use existing includeVirtualAssets to limit the processing for virtual assets - previously the lineage mappings for the virtual assets were created even though the flag was on false